### PR TITLE
Add deep link support for Places tab with coordinates

### DIFF
--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -62,15 +62,30 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
 + (instancetype)wmf_placesActivityWithURL:(NSURL *)activityURL {
     NSURLComponents *components = [NSURLComponents componentsWithURL:activityURL resolvingAgainstBaseURL:NO];
     NSURL *articleURL = nil;
+    NSNumber *latitude = nil;
+    NSNumber *longitude = nil;
+
     for (NSURLQueryItem *item in components.queryItems) {
         if ([item.name isEqualToString:@"WMFArticleURL"]) {
             NSString *articleURLString = item.value;
             articleURL = [NSURL URLWithString:articleURLString];
-            break;
+        } else if ([item.name isEqualToString:@"lat"]) {
+            latitude = @([item.value doubleValue]);
+        } else if ([item.name isEqualToString:@"lon"]) {
+            longitude = @([item.value doubleValue]);
         }
     }
+
     NSUserActivity *activity = [self wmf_pageActivityWithName:@"Places"];
     activity.webpageURL = articleURL;
+
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithObject:@"Places" forKey:@"WMFPage"];
+    if (latitude && longitude) {
+        userInfo[@"lat"] = latitude;
+        userInfo[@"lon"] = longitude;
+    }
+    activity.userInfo = userInfo;
+
     return activity;
 }
 

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -275,6 +275,12 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
 
         configureNavigationBar(titleConfig: titleConfig, closeButtonConfig: nil, profileButtonConfig: profileButtonConfig, searchBarConfig: searchConfig, hideNavigationBarOnScroll: false)
     }
+    
+    @objc(showCoordinatesWithLatitude:longitude:)
+    func showCoordinatesWithLatitude(latitude: Double, longitude: Double) {
+        locationManager.stopMonitoringLocation()
+        zoomAndPanMapView(toLocation: CLLocation(latitude: latitude, longitude: longitude))
+    }
 
     private func updateScopeBarVisibility() {
 

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -56,6 +56,8 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
     fileprivate var searching: Bool = false
     // SINGLETONTODO
     fileprivate let imageController = MWKDataStore.shared().cacheController.imageCache
+    
+    fileprivate var pendingCoordinates: CLLocation?
 
     fileprivate var _displayCountForTopPlaces: Int?
     fileprivate var displayCountForTopPlaces: Int {
@@ -235,6 +237,14 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
         locationManager.stopMonitoringLocation()
         mapView.showsUserLocation = false
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        guard let pendingCoordinates else { return }
+        showCoordinates(coordinates)
+        pendingCoordinates = nil
+    }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
@@ -278,8 +288,17 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
     
     @objc(showCoordinatesWithLatitude:longitude:)
     func showCoordinatesWithLatitude(latitude: Double, longitude: Double) {
+        let coordinates = CLLocation(latitude: latitude, longitude: longitude)
+        if viewIfLoaded != nil {
+            showCoordinates(coordinates)
+        } else {
+            pendingCoordinates = coordinates
+        }
+    }
+    
+    private func showCoordinates(_ coordinates: CLLocation) {
         locationManager.stopMonitoringLocation()
-        zoomAndPanMapView(toLocation: CLLocation(latitude: latitude, longitude: longitude))
+        zoomAndPanMapView(toLocation: coordinates)
     }
 
     private func updateScopeBarVisibility() {

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -344,8 +344,8 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     if (shouldOpenAppOnSearchTab && self.selectedIndex != WMFAppTabTypeSearch) {
         [self setSelectedIndex:WMFAppTabTypeSearch];
         [[self searchViewController] makeSearchBarBecomeFirstResponder];
-    } else if (self.selectedIndex != WMFAppTabTypeMain) {
-        [self setSelectedIndex:WMFAppTabTypeMain];
+    } else if (self.selectedIndex != WMFAppTabTypePlaces) {
+        [self setSelectedIndex:WMFAppTabTypePlaces];
     }
 }
 
@@ -1203,10 +1203,18 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
             [self dismissPresentedViewControllers];
             [self setSelectedIndex:WMFAppTabTypePlaces];
             [self.currentTabNavigationController popToRootViewControllerAnimated:animated];
+            
+            [[self placesViewController] updateViewModeToMap];
+            
+            NSNumber *latNumber = activity.userInfo[@"lat"];
+            NSNumber *lonNumber = activity.userInfo[@"lon"];
             NSURL *articleURL = activity.wmf_linkURL;
-            if (articleURL) {
-                // For "View on a map" action to succeed, view mode has to be set to map.
-                [[self placesViewController] updateViewModeToMap];
+            
+            if (latNumber && lonNumber) {
+                double lat = [latNumber doubleValue];
+                double lon = [lonNumber doubleValue];
+                [[self placesViewController] showCoordinatesWithLatitude:lat longitude:lon];
+            } else if (articleURL) {
                 [[self placesViewController] showArticleURL:articleURL];
             }
         } break;


### PR DESCRIPTION
### Notes
* 🧭 Added support for deep linking to the **Places** tab in the Wikipedia iOS app.
* 🌍 The app now supports opening with coordinates via a custom URL scheme:  
  `wikipedia://places?lat=55.6713442&lon=12.523785`
* 📍 When launched with a deep link:
  - The app opens directly to the **Places** tab.
  - The map view is activated.
  - The map zooms to and centers on the provided coordinates.

### Test Steps
1. ✅ Build and run the modified Wikipedia app on simulator or device.
2. 🚀 From another app or Safari, open a deep link like:  
   `wikipedia://places?lat=55.6713442&lon=12.523785`
3. 🗺 The app should:
   - Launch into the **Places** tab
   - Display the **Map** view
   - Center the map at the provided location
4. 🧪 Optional: Try opening `wikipedia://places` without coordinates — the app should show the default behavior (user location if authorized).